### PR TITLE
change the lock update time to be less than the stale time

### DIFF
--- a/build/docker/flexdirect/start
+++ b/build/docker/flexdirect/start
@@ -43,7 +43,7 @@ run_forever() {
       fi
       echo "$(date): $1"
     fi
-    sleep 60
+    sleep 10
 
     # keep the lock on the license directory
     echo "$(hostname)" >"${USURPLOCK}"


### PR DESCRIPTION
this fixes a bug that allowed multiple workers nodes from being able to usurp the same license. 